### PR TITLE
fix: skip BLE pairing on macOS due to platform limitations

### DIFF
--- a/easywallbox.py
+++ b/easywallbox.py
@@ -48,7 +48,7 @@ class EasyWallbox:
 
     async def pair(self):
         log.info("Pairing BLE...")
-        paired = await self._client.pair(protection_level=2)
+        paired = sys.platform == "darwin" or await self._client.pair(protection_level=2)
         log.info(f"Paired: {paired}")
 
     async def start_notify(self):

--- a/terminal.py
+++ b/terminal.py
@@ -52,7 +52,7 @@ async def wallbox_terminal(address):
     async with BleakClient(address) as client:
         print(f"Connected: {client.is_connected}")
 
-        paired = await client.pair(protection_level=1)
+        paired = sys.platform == "darwin" or await client.pair(protection_level=1)
         print(f"Paired: {paired}")
 
         await client.start_notify(BLUETOOTH_WALLBOX_TX, handle_rx)


### PR DESCRIPTION
Modify pairing logic to bypass explicit BLE pairing on macOS
by checking the platform before calling the pair method.

macOS does not support that call, it will automatically popup a pin entry GUI (the infamous 001234) as the connection is established for the first time.